### PR TITLE
Handle rejects

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ console.log(`queueLength: ${queueMw.queue.getLength()}`);
 
 For more info on Queue object used refer to [npmjs.com/package/mini-queue](https://www.npmjs.com/package/mini-queue) package docs and/or [source code](https://github.com/alykoshin/mini-queue). 
 
+## Reject handler
+
+If you set queuedLimit, when the queue is full, the middleware will reject any incoming request.
+The default handler will send a 503 status code, but you can setup your own handler with `rejectHandler` option, e.g.:
+
+```js
+  const queueMw = expressQueue({ activeLimit: 2, queuedLimit: 5, rejectHandler: (req, res) => { res.sendStatus(200); } });
+```
+
 
 ## Example
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const expressQueueMw = function(config) {
   debug('Initializing: config:', config);
 
   const self = {};
+  const rejectHandler = config.rejectHandler || defaultRejectHandler;
 
   self.jobQueue = new MiniQueue(config);
 
@@ -23,6 +24,11 @@ const expressQueueMw = function(config) {
       done();
     });
     job.data.next();
+  });
+
+  self.jobQueue.on('reject', function(job) {
+    debug('Rejected ' + job.data.req.path);
+    rejectHandler(job.data.req, job.data.res);
   });
 
   self.queueMw = function(req,res,next) {
@@ -61,6 +67,9 @@ const expressQueueMw = function(config) {
   return resultMw;
 };
 
+function defaultRejectHandler(req, res) {
+  res.status(503).send('Service busy');
+}
 
 module.exports = expressQueueMw;
 


### PR DESCRIPTION
When the queue was full, rejected jobs where left unhandled, and the request was eventually finished with a timeout.

With this PR, the middleware handles the rejects returning 503 - Service busy, and accepts a config option to set up your own handler.